### PR TITLE
Added delegate module and namespace resolution operator

### DIFF
--- a/lib/rubocop/cop/dark_finger/active_model_node_decorator.rb
+++ b/lib/rubocop/cop/dark_finger/active_model_node_decorator.rb
@@ -1,7 +1,9 @@
+require 'delegate'
+
 module RuboCop
   module Cop
     module DarkFinger
-      class ActiveModelNodeDecorator < SimpleDelegator
+      class ActiveModelNodeDecorator < ::SimpleDelegator
 
         attr_reader :misc_method_names
 


### PR DESCRIPTION
This PR changes should resolve the Codacy Rubocop error below
```
Docker exited with code 1
stdout: 
stderr: WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
java.lang.Exception: 
Rubocop exited with code 2
stdout: 
stderr: uninitialized constant RuboCop::Cop::DarkFinger::SimpleDelegator
/usr/lib/ruby/gems/2.4.0/gems/dark_finger-0.5.0/lib/rubocop/cop/dark_finger/active_model_node_decorator.rb:4:in `<module:DarkFinger>'
/usr/lib/ruby/gems/2.4.0/gems/dark_finger-0.5.0/lib/rubocop/cop/dark_finger/active_model_node_decorator.rb:3:in `<module:Cop>'
/usr/lib/ruby/gems/2.4.0/gems/dark_finger-0.5.0/lib/rubocop/cop/dark_finger/active_model_node_decorator.rb:2:in `<module:RuboCop>'
/usr/lib/ruby/gems/2.4.0/gems/dark_finger-0.5.0/lib/rubocop/cop/dark_finger/active_model_node_decorator.rb:1:in `<top (required)>'
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/lib/ruby/gems/2.4.0/gems/dark_finger-0.5.0/lib/rubocop/cop/dark_finger/model_structure.rb:1:in `<top (required)>'
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/lib/ruby/gems/2.4.0/gems/dark_finger-0.5.0/lib/dark_finger.rb:3:in `<top (required)>'
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `require'
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:39:in `require'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/config_loader_resolver.rb:15:in `block in resolve_requires'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/config_loader_resolver.rb:11:in `each'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/config_loader_resolver.rb:11:in `resolve_requires'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:43:in `load_file'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:82:in `configuration_from_file'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/config_store.rb:44:in `for'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:140:in `all_cops_include'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:122:in `ruby_extensions'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:118:in `ruby_extension?'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:162:in `ruby_file?'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:171:in `included_file?'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:177:in `block in process_explicit_path'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:177:in `select!'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:177:in `process_explicit_path'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:39:in `block in find'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:35:in `each'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/target_finder.rb:35:in `find'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/runner.rb:58:in `find_target_files'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/runner.rb:34:in `run'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/cli.rb:157:in `execute_runner'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/cli.rb:85:in `execute_runners'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/lib/rubocop/cli.rb:41:in `run'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/exe/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/usr/lib/ruby/gems/2.4.0/gems/rubocop-0.60.0/exe/rubocop:12:in `<top (required)>'
/usr/bin/rubocop:23:in `load'
/usr/bin/rubocop:23:in `<main>'
                
	at codacy.rubocop.Rubocop$.apply(Rubocop.scala:44)
	at codacy.docker.api.BackwardsCompatability$AsTool.apply(BackwardsCompatability.scala:21)
	at codacy.dockerApi.DockerEngine$$anonfun$main$1$$anonfun$apply$4.apply(DockerEngine.scala:71)
	at codacy.dockerApi.DockerEngine$$anonfun$main$1$$anonfun$apply$4.apply(DockerEngine.scala:43)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at codacy.dockerApi.DockerEngine$$anonfun$main$1.apply(DockerEngine.scala:43)
	at codacy.dockerApi.DockerEngine$$anonfun$main$1.apply(DockerEngine.scala:42)
	at scala.util.Success.flatMap(Try.scala:231)
	at codacy.dockerApi.DockerEngine.main(DockerEngine.scala:42)
	at codacy.Engine.main(Engine.scala)
```