### PR TITLE
Fix typo in key: attributes => attribute

### DIFF
--- a/docs/model_structure.md
+++ b/docs/model_structure.md
@@ -89,7 +89,7 @@ DarkFinger/ModelStructure:
     - association
     - validation
     - scope
-    - attributes
+    - attribute
     - callback
     - misc
     - constructor


### PR DESCRIPTION
The documentation example config, copy pasted into my `.rubocop.yml` resulted in an error:
```
Unknown 'required_order' model element: attributes
/Users/pboling/.asdf/installs/ruby/2.5.7/lib/ruby/gems/2.5.0/gems/dark_finger-0.6.1/lib/rubocop/cop/dark_finger/model_structure.rb:185:in `block in validate_config!'
```